### PR TITLE
Mac and Linux version of init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -5,17 +5,23 @@ BASE=`pwd`
 # Clone and compile trec_eval
 git clone https://github.com/usnistgov/trec_eval.git && make -C trec_eval
 
+WGET=wget
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	WGET="curl -O"
+fi
+
 # Download topics
 mkdir topics && cd topics
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.core17.txt
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.core18.txt
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.core17.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.core18.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/topics.robust04.301-450.601-700.txt
 
 # Back to root dir
 cd $BASE
 
 # Download qrels
 mkdir qrels && cd qrels
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.core17.txt
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.core18.txt
-wget https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.robust2004.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.core17.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.core18.txt
+$WGET https://raw.githubusercontent.com/castorini/Anserini/master/src/main/resources/topics-and-qrels/qrels.robust2004.txt
+


### PR DESCRIPTION
This version of init.sh works on Mac and probably on Linux - I don't have a Linux box handy to try it on.