### PR TITLE
Adding hashed intermediate tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ then
 ```
 python run.py search \
     --repo rclancy/anserini-test \
+    --tag latest \
     --collection [name] \
     --topic [topic_file_name] \
     --output /path/to/output \

--- a/manager.py
+++ b/manager.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 
 import docker
 
@@ -18,6 +19,7 @@ class Manager:
         self.client = docker.from_env(timeout=86_400)
         self.preparer = Preparer()
         self.searcher = Searcher()
+        self.generate_save_tag = lambda tag: hashlib.sha256((tag + "-save").encode()).hexdigest()
 
     def set_preparer_config(self, preparer_config):
         self.preparer.set_config(preparer_config)
@@ -28,9 +30,9 @@ class Manager:
     def prepare(self, preparer_config=None):
         if preparer_config:
             self.set_preparer_config(preparer_config)
-        self.preparer.prepare(self.client, COLLECTION_PATH_GUEST)
+        self.preparer.prepare(self.client, COLLECTION_PATH_GUEST, self.generate_save_tag)
 
     def search(self, searcher_config=None):
         if searcher_config:
             self.set_searcher_config(searcher_config)
-        self.searcher.search(self.client, OUTPUT_PATH_GUEST, TOPIC_PATH_HOST, TOPIC_PATH_GUEST)
+        self.searcher.search(self.client, OUTPUT_PATH_GUEST, TOPIC_PATH_HOST, TOPIC_PATH_GUEST, self.generate_save_tag)

--- a/preparer.py
+++ b/preparer.py
@@ -9,7 +9,7 @@ class Preparer:
     def set_config(self, preparer_config):
         self.config = preparer_config
 
-    def prepare(self, client, collection_path_guest):
+    def prepare(self, client, collection_path_guest, generate_save_tag):
         """
         Builds an image that has been initialized and has indexed the collection.
 
@@ -56,4 +56,4 @@ class Preparer:
         base.wait()
 
         print("Committing image...")
-        base.commit(repository=self.config.repo, tag="save")
+        base.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag))

--- a/run.py
+++ b/run.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
     parser_search = parser_sub.add_parser("search")
     parser_search.set_defaults(run=manager.search)
     parser_search.add_argument("--repo", required=True, type=str, help="the image repo (i.e., rclancy/anserini-test)")
+    parser_search.add_argument("--tag", required=True, type=str, help="the image tag (i.e., latest)")
     parser_search.add_argument("--collection", required=True, help="the name of the collection")
     parser_search.add_argument("--topic", required=True, type=str, help="the topic file for search")
     parser_search.add_argument("--topic_format", default="TREC", type=str, help="the topic file format for search")

--- a/searcher.py
+++ b/searcher.py
@@ -11,11 +11,13 @@ class Searcher:
     def set_config(self, searcher_config):
         self.config = searcher_config
 
-    def search(self, client, output_path_guest, topic_path_host, topic_path_guest):
+    def search(self, client, output_path_guest, topic_path_host, topic_path_guest, generate_save_tag):
         """
         Runs the search and evaluates the results (run files placed into the /output directory) using trec_eval
         """
-        exists = len(client.images.list(filters={"reference": "{}:{}".format(self.config.repo, "save")})) != 0
+        save_tag = generate_save_tag(self.config.tag)
+
+        exists = len(client.images.list(filters={"reference": "{}:{}".format(self.config.repo, save_tag)})) != 0
         if not exists:
             sys.exit("Must prepare image first...")
 
@@ -31,7 +33,7 @@ class Searcher:
         }
 
         print("Starting container from saved image...")
-        container = client.containers.run("{}:{}".format(self.config.repo, "save"),
+        container = client.containers.run("{}:{}".format(self.config.repo, save_tag),
                                           command="sh -c '/search --collection {} --topic {} --topic_format {}'".format(
                                               self.config.collection, self.config.topic, self.config.topic_format), volumes=volumes, detach=True)
 


### PR DESCRIPTION
Addresses #10 

The reason I decided to use hashing is because if we make a tag by simply append something like "-save" to existing tag, then what if the existing tag is already at maximum length allowed for tags (which I think is set at 128 characters right now)? Of course, we could in our specifications explicitly limit the tag length for our users, but that's unnecessary when a better solution would be to simply hash the existing tag to produce a fixed-length intermediate tag, especially since these intermediate tags are not meant to be read by users anyway.