### PR TITLE
Configurable intermediate image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ To test the jig with an Anserini image, try:
 
 ```
 python run.py prepare \
-    --repo rclancy/anserini-test --tag latest \
+    --repo rclancy/anserini-test \
+    --tag latest \
+    --save_tag [tag] \
     --collections [name]=[path] [name]=[path] ...
 ```
 
@@ -18,6 +20,7 @@ then
 python run.py search \
     --repo rclancy/anserini-test \
     --tag latest \
+    --save_tag [tag] \
     --collection [name] \
     --topic [topic_file_name] \
     --top_k [num] \

--- a/manager.py
+++ b/manager.py
@@ -19,7 +19,7 @@ class Manager:
         self.client = docker.from_env(timeout=86_400)
         self.preparer = Preparer()
         self.searcher = Searcher()
-        self.generate_save_tag = lambda tag, save_tag: hashlib.sha256((tag + save_tag).encode()).hexdigest()
+        self.generate_save_tag = lambda tag, save_id: hashlib.sha256((tag + save_id).encode()).hexdigest()
 
     def set_preparer_config(self, preparer_config):
         self.preparer.set_config(preparer_config)

--- a/manager.py
+++ b/manager.py
@@ -19,7 +19,7 @@ class Manager:
         self.client = docker.from_env(timeout=86_400)
         self.preparer = Preparer()
         self.searcher = Searcher()
-        self.generate_save_tag = lambda tag: hashlib.sha256((tag + "-save").encode()).hexdigest()
+        self.generate_save_tag = lambda tag, save_tag: hashlib.sha256((tag + save_tag).encode()).hexdigest()
 
     def set_preparer_config(self, preparer_config):
         self.preparer.set_config(preparer_config)

--- a/preparer.py
+++ b/preparer.py
@@ -56,4 +56,4 @@ class Preparer:
         base.wait()
 
         print("Committing image...")
-        base.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag))
+        base.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag, self.config.save_tag))

--- a/preparer.py
+++ b/preparer.py
@@ -56,4 +56,4 @@ class Preparer:
         base.wait()
 
         print("Committing image...")
-        base.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag, self.config.save_tag))
+        base.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag, self.config.save_id))

--- a/run.py
+++ b/run.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     parser_prepare.set_defaults(run=manager.prepare)
     parser_prepare.add_argument("--repo", required=True, type=str, help="the image repo (i.e., rclancy/anserini-test)")
     parser_prepare.add_argument("--tag", required=True, type=str, help="the image tag (i.e., latest)")
-    parser_prepare.add_argument("--save_tag", default="save", type=str, help="the tag of the saved image (to search from)")
+    parser_prepare.add_argument("--save_id", default="save", type=str, help="the ID of the saved image (to search from)")
     parser_prepare.add_argument("--collections", required=True, nargs="+", help="the name of the collection")
 
     # Specific to search
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     parser_search.set_defaults(run=manager.search)
     parser_search.add_argument("--repo", required=True, type=str, help="the image repo (i.e., rclancy/anserini-test)")
     parser_search.add_argument("--tag", required=True, type=str, help="the image tag (i.e., latest)")
-    parser_search.add_argument("--save_tag", default="save", type=str, help="the tag of the saved image (to search from)")
+    parser_search.add_argument("--save_id", default="save", type=str, help="the ID of the saved image (to search from)")
     parser_search.add_argument("--collection", required=True, help="the name of the collection")
     parser_search.add_argument("--topic", required=True, type=str, help="the topic file for search")
     parser_search.add_argument("--topic_format", default="TREC", type=str, help="the topic file format for search")

--- a/run.py
+++ b/run.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
     parser_prepare.set_defaults(run=manager.prepare)
     parser_prepare.add_argument("--repo", required=True, type=str, help="the image repo (i.e., rclancy/anserini-test)")
     parser_prepare.add_argument("--tag", required=True, type=str, help="the image tag (i.e., latest)")
+    parser_prepare.add_argument("--save_tag", default="save", type=str, help="the tag of the saved image (to search from)")
     parser_prepare.add_argument("--collections", required=True, nargs="+", help="the name of the collection")
 
     # Specific to search
@@ -20,6 +21,7 @@ if __name__ == "__main__":
     parser_search.set_defaults(run=manager.search)
     parser_search.add_argument("--repo", required=True, type=str, help="the image repo (i.e., rclancy/anserini-test)")
     parser_search.add_argument("--tag", required=True, type=str, help="the image tag (i.e., latest)")
+    parser_search.add_argument("--save_tag", default="save", type=str, help="the tag of the saved image (to search from)")
     parser_search.add_argument("--collection", required=True, help="the name of the collection")
     parser_search.add_argument("--topic", required=True, type=str, help="the topic file for search")
     parser_search.add_argument("--topic_format", default="TREC", type=str, help="the topic file format for search")

--- a/searcher.py
+++ b/searcher.py
@@ -15,7 +15,7 @@ class Searcher:
         """
         Runs the search and evaluates the results (run files placed into the /output directory) using trec_eval
         """
-        save_tag = generate_save_tag(self.config.tag)
+        save_tag = generate_save_tag(self.config.tag, self.config.save_tag)
 
         exists = len(client.images.list(filters={"reference": "{}:{}".format(self.config.repo, save_tag)})) != 0
         if not exists:

--- a/searcher.py
+++ b/searcher.py
@@ -15,7 +15,7 @@ class Searcher:
         """
         Runs the search and evaluates the results (run files placed into the /output directory) using trec_eval
         """
-        save_tag = generate_save_tag(self.config.tag, self.config.save_tag)
+        save_tag = generate_save_tag(self.config.tag, self.config.save_id)
 
         exists = len(client.images.list(filters={"reference": "{}:{}".format(self.config.repo, save_tag)})) != 0
         if not exists:


### PR DESCRIPTION
Made intermediate image tag configurable by including in the hash the `save_id` argument provided from command line. This way, users can save and search from multiple images derived from the same original image `<repo>:<tag>` but possibly indexed with different collections.