### PR TITLE
Support for "format" parameters and change params to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Before the hook is run, we will mount the document collections at a path passed 
 
 The script will be executed as: `./index --json <json> ` where the JSON string has the following format:
 
-```json
+```json5
 {
   "collections": [
     {
@@ -102,7 +102,7 @@ The purpose of the `search` hook is to perform the ad-hoc retreival runs.
 The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
 
 The script will be executed as `./search --json <json>` where the JSON string has the following format:
-```json
+```json5
 {
   "collection": {
     "name": "<name>"          // the collection name

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options with `none` as the default are required.
 
 Currently we support three hooks: `init`, `index`, and `search` (called in that order). We expect these three executables to be located in the root directory of the container.
 
-Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies installed. 
+Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies are installed. 
 
 ### init
 The purpose of the `init` hook is to do any preperation needed for the run - this could be downloading + compiling code, downloading a pre-built artifact, or downloading external resources (pre-trained models, knowledge graphs, etc.).
@@ -79,21 +79,41 @@ The script will be executed as `./init` with no arguments.
 ### index
 The purpose of the `index` hook is to build the indexes required for the run.
 
-Before the hook is run, we will mount the appropriate document collections at `/input/collections/<name>`, so your script should expect the appropriate collections to be mounted there.
+Before the hook is run, we will mount the document collections at a path passed to the script.
 
-The script will be executed as: `./index --collections <name> <name> ...` where...
-- `--collections <name> <name> ...` is a space-delimited list of collection names that map into `/input/collections/<name>`
+The script will be executed as: `./index --json <json> ` where the JSON string has the following format:
+
+```json
+{
+  "collections": [
+    {
+      "name": "<name>",              // the collection name
+      "path": "/path/to/collection", // the collection path
+      "format": "<format>"           // the collection format (trectext, trecweb, json, warc)
+    },
+    ...
+  ]
+}
+```
 
 ### search
 The purpose of the `search` hook is to perform the ad-hoc retreival runs.
 
 The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
 
-The script will be executed as `./search --collection <name> --topic <topic> --topic_format <topic_format> --top_k <num>` where...
-- `--collection <name>` is the name of the collection being run on (same as the `index` script, so you can map back to the location you chose to store the index)
-- `--topic <topic>` is the topic file that maps to `/input/topics/<topic>` 
-- `--topic_format <topic_format>` is the format of the topic file
-- `--top_k <num>` is the number of retrieval results for top-k runs
+The script will be executed as `./search --json <json>` where the JSON string has the following format:
+```json
+{
+  "collection": {
+    "name": "<name>"          // the collection name
+  },
+  "topic": {
+    "path": "/path/to/topic", // the path to the topic file
+    "format": "trec"          // the format of the topic file
+  },
+  "top_k": <int>              // the num of retrieval results for top-k retrieval
+}
+```
 
 # Docker Container Contract
 

--- a/searcher.py
+++ b/searcher.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -32,12 +33,18 @@ class Searcher:
             },
         }
 
+        search_args = {
+            "collection": self.config.collection,
+            "topic": self.config.topic,
+            "topic_format": self.config.topic_format,
+            "top_k": self.config.top_k
+        }
+
         print("Starting container from saved image...")
         container = client.containers.run("{}:{}".format(self.config.repo, save_tag),
-                                          command="sh -c '/search --collection {} --topic {} --topic_format {} --top_k {}'".format(
-                                              self.config.collection, self.config.topic, self.config.topic_format, self.config.top_k), volumes=volumes, detach=True)
+                                          command="sh -c '/search --json {}'".format(json.dumps(json.dumps(search_args))), volumes=volumes, detach=True)
 
-        print("Waiting for search to finish...")
+        print("Waiting for search to finish in container '{}'...".format(container.name))
         container.wait()
 
         print("Evaluating results using trec_eval...")

--- a/searcher.py
+++ b/searcher.py
@@ -34,7 +34,9 @@ class Searcher:
         }
 
         search_args = {
-            "collection": self.config.collection,
+            "collection": {
+                "name": self.config.collection
+            },
             "topic": self.config.topic,
             "topic_format": self.config.topic_format,
             "top_k": self.config.top_k


### PR DESCRIPTION
Proposal for changing the params to JSON... we serialize a dict as JSON on the `jig` side and on the image side use `argparse`'s `type=json.loads`  to deserialize - see https://github.com/osirrc2019/anserini-docker/pull/10

This helps with making minor changes non-breaking (adding the `format` param was breaking, in the future similar changes will be an additional field) and makes grouping related info (collection name, format, path, etc.) easier.

~~Still needs to doc changes where we define the schema for the JSON (i.e., a collections array where each object has name, path, format, etc. properties - just like the current command-line args), but it seems to work well with `anserini-docker` in the PR linked above.~~

Edit: Docs updated.