### PR TITLE
Allow options to be passed through to index and search scripts...

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Before the hook is run, we will mount the document collections at a path passed 
 
 The script will be executed as: `./index --json <json> ` where the JSON string has the following format:
 
-```json
+```json5
 {
   "collections": [
     {
@@ -102,7 +102,7 @@ The purpose of the `search` hook is to perform the ad-hoc retreival runs.
 The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
 
 The script will be executed as `./search --json <json>` where the JSON string has the following format:
-```json
+```json5
 {
   "collection": {
     "name": "<name>"          // the collection name

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Options with `none` as the default are required.
 | `--tag` | `string` | `latest` | `--latest` | the tag on Docker Hub
 | `--collections` | `[name]=[path]=[format] ...` | `none` | `--collections robust04=/path/to/robust04=trectext ...` | the collections to index
 | `--save_id` | `string` | `save` | `--save_id robust04-exp1` | the ID for intermediate image after indexing
-| `--opts` | `string` | `none` | `-storeRawDocs` | extra options passed to the index script
+| `--opts` | `[key]=[value] ...` | `none` | `--opts index_args="-storeRawDocs"` | extra options passed to the index script
 
 ### Command Line Options - search
 
@@ -65,7 +65,7 @@ Options with `none` as the default are required.
 | `--top_k` | `int` | `1000` | `--top_k 500` | the number of results for top-k retrieval
 | `--output` | `string` | `none` | `--output $(pwd)/output` | the output path for run files
 | `--qrels` | `string` | `none` | `--qrels $(pwd)/qrels/qrels.robust2004.txt` | the qrels file for evaluation
-| `--opts` | `string` | `none` | `-bm25` | extra options passed to the search script
+| `--opts` | `[key]=[value] ...` | `none` | `--opts search_args="-bm25"` | extra options passed to the search script
 
 # Docker Container Contract
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Currently we support three hooks: `init`, `index`, and `search` (called in that 
 Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies are installed. 
 
 ### init
-The purpose of the `init` hook is to do any preperation needed for the run - this could be downloading + compiling code, downloading a pre-built artifact, or downloading external resources (pre-trained models, knowledge graphs, etc.).
+The purpose of the `init` hook is to do any preparation needed for the run - this could be downloading + compiling code, downloading a pre-built artifact, or downloading external resources (pre-trained models, knowledge graphs, etc.).
 
 The script will be executed as `./init` with no arguments.
 
@@ -100,7 +100,7 @@ The script will be executed as: `./index --json <json> ` where the JSON string h
 ```
 
 ### search
-The purpose of the `search` hook is to perform the ad-hoc retreival runs.
+The purpose of the `search` hook is to perform an ad-hoc retrieval run - multiple runs can be performed by calling `jig` multiple times with different `--opts` parameters.
 
 The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
 
@@ -118,35 +118,6 @@ The script will be executed as `./search --json <json>` where the JSON string ha
   "top_k": <int>              // the num of retrieval results for top-k retrieval
 }
 ```
-
-# Docker Container Contract
-
-Currently we support three hooks: `init`, `index`, and `search` (called in that order). We expect these three executables to be located in the root directory of the container.
-
-Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies installed. 
-
-### init
-The purpose of the `init` hook is to do any preperation needed for the run - this could be downloading + compiling code, downloading a pre-built artifact, or downloading external resources (pre-trained models, knowledge graphs, etc.).
-
-The script will be executed as `./init` with no arguments.
-
-### index
-The purpose of the `index` hook is to build the indexes required for the run.
-
-Before the hook is run, we will mount the appropriate document collections at `/input/collections/<name>`, so your script should expect the appropriate collections to be mounted there.
-
-The script will be executed as: `./index --collections <name> <name> ...` where...
-- `--collections <name> <name> ...` is a space-delimited list of collection names that map into `/input/collections/<name>`
-
-### search
-The purpose of the `search` hook is to perform the ad-hoc retreival runs.
-
-The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
-
-The script will be executed as `./search --collection <name> --topic <topic> --topic_format <topic_format>` where...
-- `--collection <name>` is the name of the collection being run on (same as the `index` script, so you can map back to the location you chose to store the index)
-- `--topic <topic>` is the topic file that maps to `/input/topics/<topic>` 
-- `--topic_format <topic_format>` is the format of the topic file
 
 ## Reference Images
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Options with `none` as the default are required.
 | --- | --- | --- | --- | ---
 | `--repo` | `string` | `none` | `--repo osirrc2019/anserini` | the repo on Docker Hub
 | `--tag` | `string` | `latest` | `--latest` | the tag on Docker Hub
-| `--collections` | `[name]=[path] ...` | `none` | `--collections robust04=/path/to/robust04 ...` | the collections to index
+| `--collections` | `[name]=[path]=[format] ...` | `none` | `--collections robust04=/path/to/robust04=trectext ...` | the collections to index
 | `--save_id` | `string` | `save` | `--save_id robust04-exp1` | the ID for intermediate image after indexing
+| `--opts` | `string` | `none` | `-storeRawDocs` | extra options passed to the index script
 
 ### Command Line Options - search
 
@@ -64,6 +65,7 @@ Options with `none` as the default are required.
 | `--top_k` | `int` | `1000` | `--top_k 500` | the number of results for top-k retrieval
 | `--output` | `string` | `none` | `--output $(pwd)/output` | the output path for run files
 | `--qrels` | `string` | `none` | `--qrels $(pwd)/qrels/qrels.robust2004.txt` | the qrels file for evaluation
+| `--opts` | `string` | `none` | `-bm25` | extra options passed to the search script
 
 # Docker Container Contract
 
@@ -92,7 +94,8 @@ The script will be executed as: `./index --json <json> ` where the JSON string h
       "format": "<format>"           // the collection format (trectext, trecweb, json, warc)
     },
     ...
-  ]
+  ],
+  "opts": "<options>"                // extra options passed to the index script
 }
 ```
 
@@ -107,6 +110,7 @@ The script will be executed as `./search --json <json>` where the JSON string ha
   "collection": {
     "name": "<name>"          // the collection name
   },
+  "opts": "<options>",        // extra options passed to the search script
   "topic": {
     "path": "/path/to/topic", // the path to the topic file
     "format": "trec"          // the format of the topic file

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options with `none` as the default are required.
 
 Currently we support three hooks: `init`, `index`, and `search` (called in that order). We expect these three executables to be located in the root directory of the container.
 
-Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies installed. 
+Each script is executed with the interpreter determined by the shebang so you can use  `#!/usr/bin/env bash`, `#!/usr/bin/env python3`, etc - just remember to make sure your `Dockerfile` is built with the appropriate base image or the required dependencies are installed. 
 
 ### init
 The purpose of the `init` hook is to do any preperation needed for the run - this could be downloading + compiling code, downloading a pre-built artifact, or downloading external resources (pre-trained models, knowledge graphs, etc.).
@@ -79,21 +79,41 @@ The script will be executed as `./init` with no arguments.
 ### index
 The purpose of the `index` hook is to build the indexes required for the run.
 
-Before the hook is run, we will mount the appropriate document collections at `/input/collections/<name>`, so your script should expect the appropriate collections to be mounted there.
+Before the hook is run, we will mount the document collections at a path passed to the script.
 
-The script will be executed as: `./index --collections <name> <name> ...` where...
-- `--collections <name> <name> ...` is a space-delimited list of collection names that map into `/input/collections/<name>`
+The script will be executed as: `./index --json <json> ` where the JSON string has the following format:
+
+```json
+{
+  "collections": [
+    {
+      "name": "<name>",              // the collection name
+      "path": "/path/to/collection", // the collection path
+      "format": "<format>"           // the collection format (trectext, trecweb, json, warc)
+    },
+    ...
+  ]
+}
+```
 
 ### search
 The purpose of the `search` hook is to perform the ad-hoc retreival runs.
 
 The run files are expected to be placed in the `/output` directory such that they can be evaluated externally by `jig` using `trec_eval`.
 
-The script will be executed as `./search --collection <name> --topic <topic> --topic_format <topic_format> --top_k <num>` where...
-- `--collection <name>` is the name of the collection being run on (same as the `index` script, so you can map back to the location you chose to store the index)
-- `--topic <topic>` is the topic file that maps to `/input/topics/<topic>` 
-- `--topic_format <topic_format>` is the format of the topic file
-- `--top_k <num>` is the number of retrieval results for top-k runs
+The script will be executed as `./search --json <json>` where the JSON string has the following format:
+```json
+{
+  "collection": {
+    "name": "<name>"          // the collection name
+  },
+  "topic": {
+    "path": "/path/to/topic", // the path to the topic file
+    "format": "trec"          // the format of the topic file
+  },
+  "top_k": <int>              // the num of retrieval results for top-k retrieval
+}
+```
 
 # Docker Container Contract
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ The script will be executed as: `./index --json <json> ` where the JSON string h
     },
     ...
   ],
-  "opts": "<options>"                // extra options passed to the index script
+  "opts": [ // extra options passed to the index script
+    {
+      "key": "<key>",
+      "value": "<value>"
+    },
+    ...
+  ]
 }
 ```
 
@@ -110,7 +116,13 @@ The script will be executed as `./search --json <json>` where the JSON string ha
   "collection": {
     "name": "<name>"          // the collection name
   },
-  "opts": "<options>",        // extra options passed to the search script
+  "opts": [ // extra options passed to the search script
+    {
+      "key": "<key>",
+      "value": "<value>"
+    },
+    ...
+  ],
   "topic": {
     "path": "/path/to/topic", // the path to the topic file
     "format": "trec"          // the format of the topic file

--- a/README.md
+++ b/README.md
@@ -95,13 +95,9 @@ The script will be executed as: `./index --json <json> ` where the JSON string h
     },
     ...
   ],
-  "opts": [ // extra options passed to the index script
-    {
-      "key": "<key>",
-      "value": "<value>"
-    },
-    ...
-  ]
+  "opts": { // extra options passed to the index script
+    "<key>": "<value>"
+  },
 }
 ```
 
@@ -116,13 +112,9 @@ The script will be executed as `./search --json <json>` where the JSON string ha
   "collection": {
     "name": "<name>"          // the collection name
   },
-  "opts": [ // extra options passed to the search script
-    {
-      "key": "<key>",
-      "value": "<value>"
-    },
-    ...
-  ],
+  "opts": { // extra options passed to the search script
+    "<key>": "<value>"
+  },
   "topic": {
     "path": "/path/to/topic", // the path to the topic file
     "format": "trec"          // the format of the topic file

--- a/preparer.py
+++ b/preparer.py
@@ -53,7 +53,7 @@ class Preparer:
 
         index_args = {
             "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format) in collections],
-            "opts": [{"key": key, "value": value} for (key, value) in map(lambda x: x.split("="), self.config.opts)],
+            "opts": {key: value for (key, value) in map(lambda x: x.split("="), self.config.opts)},
         }
 
         # The first step is to pull an image from an OSIRRC participant,

--- a/preparer.py
+++ b/preparer.py
@@ -52,7 +52,8 @@ class Preparer:
             }
 
         index_args = {
-            "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format) in collections]
+            "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format) in collections],
+            "opts": self.config.opts
         }
 
         # The first step is to pull an image from an OSIRRC participant,
@@ -62,7 +63,7 @@ class Preparer:
         # while, but only needs to be done once, so in essence we are
         # "snapshotting" the system with the indexes.
         container = client.containers.run("{}:{}".format(self.config.repo, self.config.tag),
-                                     command="sh -c '/init; /index --json {}'".format(json.dumps(json.dumps(index_args))), volumes=volumes, detach=True)
+                                          command="sh -c '/init; /index --json {}'".format(json.dumps(json.dumps(index_args))), volumes=volumes, detach=True)
 
         print("Waiting for init and index to finish in container '{}'...".format(container.name))
         container.wait()

--- a/preparer.py
+++ b/preparer.py
@@ -53,7 +53,7 @@ class Preparer:
 
         index_args = {
             "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format) in collections],
-            "opts": self.config.opts
+            "opts": [{"key": key, "value": value} for (key, value) in map(lambda x: x.split("="), self.config.opts)],
         }
 
         # The first step is to pull an image from an OSIRRC participant,

--- a/run.py
+++ b/run.py
@@ -15,6 +15,7 @@ if __name__ == "__main__":
     parser_prepare.add_argument("--tag", default="latest", type=str, help="the image tag (i.e., latest)")
     parser_prepare.add_argument("--save_id", default="save", type=str, help="the ID of the saved image (to search from)")
     parser_prepare.add_argument("--collections", required=True, nargs="+", help="the name of the collection")
+    parser_prepare.add_argument("--opts", default="", type=str, help="the args passed to the index script")
 
     # Specific to search
     parser_search = parser_sub.add_parser("search")
@@ -28,6 +29,7 @@ if __name__ == "__main__":
     parser_search.add_argument("--top_k", default=1000, type=int, help="the number of results for top-k retrieval")
     parser_search.add_argument("--output", required=True, type=str, help="the output directory for run files on the host")
     parser_search.add_argument("--qrels", required=True, type=str, help="the qrels file for evaluation")
+    parser_search.add_argument("--opts", default="", type=str, help="the args passed to the search script")
 
     # Parse the args
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     parser_prepare.add_argument("--tag", default="latest", type=str, help="the image tag (i.e., latest)")
     parser_prepare.add_argument("--save_id", default="save", type=str, help="the ID of the saved image (to search from)")
     parser_prepare.add_argument("--collections", required=True, nargs="+", help="the name of the collection")
-    parser_prepare.add_argument("--opts", default="", type=str, help="the args passed to the index script")
+    parser_prepare.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the index script")
 
     # Specific to search
     parser_search = parser_sub.add_parser("search")
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     parser_search.add_argument("--top_k", default=1000, type=int, help="the number of results for top-k retrieval")
     parser_search.add_argument("--output", required=True, type=str, help="the output directory for run files on the host")
     parser_search.add_argument("--qrels", required=True, type=str, help="the qrels file for evaluation")
-    parser_search.add_argument("--opts", default="", type=str, help="the args passed to the search script")
+    parser_search.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the search script")
 
     # Parse the args
     args = parser.parse_args()

--- a/searcher.py
+++ b/searcher.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -32,12 +33,18 @@ class Searcher:
             },
         }
 
+        search_args = {
+            "collection": self.config.collection,
+            "topic": self.config.topic,
+            "topic_format": self.config.topic_format,
+            "top_k": self.config.top_k
+        }
+
         print("Starting container from saved image...")
         container = client.containers.run("{}:{}".format(self.config.repo, save_tag),
-                                          command="sh -c '/search --collection {} --topic {} --topic_format {} --top_k {}'".format(
-                                              self.config.collection, self.config.topic, self.config.topic_format, self.config.top_k), volumes=volumes, detach=True)
+                                          command="sh -c '/search --json {}'".format(json.dumps(json.dumps(search_args))), volumes=volumes, detach=True)
 
-        print("Waiting for search to finish...")
+        print("Waiting for search to finish in container '{}'...".format(container.name))
         container.wait()
 
         print("Evaluating results using trec_eval...")

--- a/searcher.py
+++ b/searcher.py
@@ -37,7 +37,7 @@ class Searcher:
             "collection": {
                 "name": self.config.collection
             },
-            "opts": [{"key": key, "value": value} for (key, value) in map(lambda x: x.split("="), self.config.opts)],
+            "opts": {key: value for (key, value) in map(lambda x: x.split("="), self.config.opts)},
             "topic": self.config.topic,
             "topic_format": self.config.topic_format,
             "top_k": self.config.top_k

--- a/searcher.py
+++ b/searcher.py
@@ -37,7 +37,7 @@ class Searcher:
             "collection": {
                 "name": self.config.collection
             },
-            "opts": self.config.opts,
+            "opts": [{"key": key, "value": value} for (key, value) in map(lambda x: x.split("="), self.config.opts)],
             "topic": self.config.topic,
             "topic_format": self.config.topic_format,
             "top_k": self.config.top_k

--- a/searcher.py
+++ b/searcher.py
@@ -37,6 +37,7 @@ class Searcher:
             "collection": {
                 "name": self.config.collection
             },
+            "opts": self.config.opts,
             "topic": self.config.topic,
             "topic_format": self.config.topic_format,
             "top_k": self.config.top_k

--- a/searcher.py
+++ b/searcher.py
@@ -34,7 +34,9 @@ class Searcher:
         }
 
         search_args = {
-            "collection": self.config.collection,
+            "collection": {
+                "name": self.config.collection
+            },
             "topic": self.config.topic,
             "topic_format": self.config.topic_format,
             "top_k": self.config.top_k


### PR DESCRIPTION
This means that each run of `python run.py search ...` can be a single retrieval run - this is useful for efficiency measures (see https://github.com/osirrc2019/jig/issues/36). 

We can pass in extra options such as `--opts search_args="-bm25 -rm3" output="run.bm25.rm3" ...`