### PR TITLE
Added optional --output parameter to jig

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -17,7 +17,7 @@ OUTPUT_PATH_GUEST = "/output"
 class Manager:
 
     def __init__(self):
-        self.client = docker.from_env(timeout=86_400)
+        self.client = docker.from_env(timeout=400)
         self.preparer = Preparer()
         self.searcher = Searcher()
         self.interactor = Interactor()
@@ -28,14 +28,14 @@ class Manager:
 
     def set_searcher_config(self, searcher_config):
         self.searcher.set_config(searcher_config)
-    
+
     def set_interactor_config(self, interactor_config):
         self.interactor.set_config(interactor_config)
 
     def prepare(self, preparer_config=None):
         if preparer_config:
             self.set_preparer_config(preparer_config)
-        self.preparer.prepare(self.client, COLLECTION_PATH_GUEST, self.generate_save_tag)
+        self.preparer.prepare(self.client, COLLECTION_PATH_GUEST, OUTPUT_PATH_GUEST, self.generate_save_tag)
 
     def search(self, searcher_config=None):
         if searcher_config:

--- a/preparer.py
+++ b/preparer.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 import sys
@@ -11,7 +12,7 @@ class Preparer:
     def set_config(self, preparer_config):
         self.config = preparer_config
 
-    def prepare(self, client, collection_path_guest, generate_save_tag):
+    def prepare(self, client, collection_path_guest, output_path_guest, generate_save_tag):
         """
         Builds an image that has been initialized and has indexed the collection.
 
@@ -40,7 +41,8 @@ class Preparer:
         name_to_path_host = dict(map(lambda x: (x[0], x[1]), collections))
 
         # Mapping from collection name to path in container
-        name_to_path_guest = dict(map(lambda name: (name, os.path.join(collection_path_guest, name)), name_to_path_host.keys()))
+        name_to_path_guest = dict(
+            map(lambda name: (name, os.path.join(collection_path_guest, name)), name_to_path_host.keys()))
 
         volumes = {}
 
@@ -50,6 +52,9 @@ class Preparer:
                 "bind": path_guest,
                 "mode": "ro"
             }
+        # mount optional output folder. Mounted on guest "/output" path.
+        if len(self.config.output) > 0:
+            volumes[self.config.output] = {"bind": output_path_guest, "mode": "rw"}
 
         init_args = {
             "opts": {key: value for (key, value) in map(lambda x: x.split("="), self.config.opts)},
@@ -57,7 +62,8 @@ class Preparer:
         }
 
         index_args = {
-            "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format) in collections],
+            "collections": [{"name": name, "path": name_to_path_guest[name], "format": format} for (name, path, format)
+                            in collections],
             "opts": {key: value for (key, value) in map(lambda x: x.split("="), self.config.opts)}
         }
 
@@ -68,8 +74,9 @@ class Preparer:
         # while, but only needs to be done once, so in essence we are
         # "snapshotting" the system with the indexes.
         container = client.containers.run("{}:{}".format(self.config.repo, self.config.tag),
-                                          command="sh -c '/init --json {}; /index --json {}'".format(json.dumps(json.dumps(init_args)),
-                                                                                                     json.dumps(json.dumps(index_args))),
+                                          command="sh -c '/init --json {}; /index --json {}'".format(
+                                              json.dumps(json.dumps(init_args)),
+                                              json.dumps(json.dumps(index_args))),
                                           volumes=volumes, detach=True)
 
         print("Logs for init and index in container with ID {}...".format(container.id))
@@ -77,4 +84,5 @@ class Preparer:
             print(str(line.decode('utf-8')), end="")
 
         print("Committing image...")
-        container.commit(repository=self.config.repo, tag=generate_save_tag(self.config.tag, self.config.save_to_snapshot))
+        container.commit(repository=self.config.repo,
+                         tag=generate_save_tag(self.config.tag, self.config.save_to_snapshot))

--- a/run.py
+++ b/run.py
@@ -2,14 +2,15 @@ import argparse
 
 from manager import Manager
 
+
 def str_to_bool(s):
-        s = s.lower()
-        if s == "true":
-            return True
-        elif s == "false":
-            return False
-        else:
-            raise argparse.ArgumentTypeError("Expected boolean value.")
+    s = s.lower()
+    if s == "true":
+        return True
+    elif s == "false":
+        return False
+    else:
+        raise argparse.ArgumentTypeError("Expected boolean value.")
 
 
 if __name__ == "__main__":
@@ -23,8 +24,11 @@ if __name__ == "__main__":
     parser_prepare.set_defaults(run=manager.prepare)
     parser_prepare.add_argument("--repo", required=True, type=str, help="the image repo (i.e., osirrc2019/anserini)")
     parser_prepare.add_argument("--tag", default="latest", type=str, help="the image tag (i.e., latest)")
-    parser_prepare.add_argument("--save_to_snapshot", default="save", type=str, help="used to determine the tag of the snapshotted image after indexing")
+    parser_prepare.add_argument("--save_to_snapshot", default="save", type=str,
+                                help="used to determine the tag of the snapshotted image after indexing")
     parser_prepare.add_argument("--collections", required=True, nargs="+", help="the name of the collection")
+    parser_prepare.add_argument("--output", default="", required=False, type=str,
+                                help="the path to the output folder for the index files")
     parser_prepare.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the index script")
     parser_prepare.add_argument("--version", default="", type=str, help="the version string passed to the init script")
 
@@ -33,12 +37,14 @@ if __name__ == "__main__":
     parser_search.set_defaults(run=manager.search)
     parser_search.add_argument("--repo", required=True, type=str, help="the image repo (i.e., osirrc2019/anserini)")
     parser_search.add_argument("--tag", default="latest", type=str, help="the image tag (i.e., latest)")
-    parser_search.add_argument("--load_from_snapshot", default="save", type=str, help="used to determine the tag of the snapshotted image to search from")
+    parser_search.add_argument("--load_from_snapshot", default="save", type=str,
+                               help="used to determine the tag of the snapshotted image to search from")
     parser_search.add_argument("--collection", required=True, help="the name of the collection")
     parser_search.add_argument("--topic", required=True, type=str, help="the topic file for search")
     parser_search.add_argument("--topic_format", default="trec", type=str, help="the topic file format for search")
     parser_search.add_argument("--top_k", default=1000, type=int, help="the number of results for top-k retrieval")
-    parser_search.add_argument("--output", required=True, type=str, help="the output directory for run files on the host")
+    parser_search.add_argument("--output", required=True, type=str,
+                               help="the output directory for run files on the host")
     parser_search.add_argument("--qrels", required=True, type=str, help="the qrels file for evaluation")
     parser_search.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the search script")
 
@@ -47,9 +53,12 @@ if __name__ == "__main__":
     parser_interact.set_defaults(run=manager.interact)
     parser_interact.add_argument("--repo", required=True, type=str, help="the image repo (i.e., osirrc2019/anserini)")
     parser_interact.add_argument("--tag", default="latest", type=str, help="the image tag (i.e., latest)")
-    parser_interact.add_argument("--load_from_snapshot", default="save", type=str, help="used to determine the tag of the snapshotted image to interact with")
-    parser_interact.add_argument("--exit_jig", default="false", type=str_to_bool, help="whether to exit jig after running container")
-    parser_interact.add_argument("--opts", nargs="+", default="", type=str, help="the args passed to the interact script")
+    parser_interact.add_argument("--load_from_snapshot", default="save", type=str,
+                                 help="used to determine the tag of the snapshotted image to interact with")
+    parser_interact.add_argument("--exit_jig", default="false", type=str_to_bool,
+                                 help="whether to exit jig after running container")
+    parser_interact.add_argument("--opts", nargs="+", default="", type=str,
+                                 help="the args passed to the interact script")
 
     # Parse the args
     args = parser.parse_args()


### PR DESCRIPTION
Added optional --output parameter for the prepare script. The user can specify in the --opts arg a path where to mount the host folder specified in --output to the "/output" guest path in order to save the index or other data created during the indexing/initialization process. If not provided no host directory is mounted in the "/output" guest path.