### PR TITLE
Publish all ports that are EXPOSE'd in the Dockerfile for interact hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ The script will be executed as `./interact --json <json>` where the JSON string 
 }
 ```
 
+Note: If you need a port accessible, ensure you `EXPOSE` the port in your `Dockerfile`.
+
 ## Reference Images
 
 + Anserini: [[code](https://github.com/osirrc2019/anserini-docker)] [[Docker Hub](https://hub.docker.com/r/rclancy/anserini-test)]

--- a/interactor.py
+++ b/interactor.py
@@ -30,7 +30,7 @@ class Interactor:
 
         print("Starting a container from saved image...")
         # create with sh command to override any default command
-        container = client.containers.create("{}:{}".format(self.config.repo, save_tag), command="sh", tty=True)
+        container = client.containers.create("{}:{}".format(self.config.repo, save_tag), command="sh", tty=True, publish_all_ports=True)
         container.start()
 
         print("Running interact script in container...")

--- a/preparer.py
+++ b/preparer.py
@@ -70,7 +70,7 @@ class Preparer:
         container = client.containers.run("{}:{}".format(self.config.repo, self.config.tag),
                                           command="sh -c '/init --json {}; /index --json {}'".format(json.dumps(json.dumps(init_args)),
                                                                                                      json.dumps(json.dumps(index_args))),
-                                          volumes=volumes, detach=True)
+                                          volumes=volumes, detach=True, publish_all_ports=True)
 
         print("Logs for init and index in container with ID {}...".format(container.id))
         for line in container.logs(stream=True):

--- a/searcher.py
+++ b/searcher.py
@@ -47,7 +47,8 @@ class Searcher:
 
         print("Starting container from saved image...")
         container = client.containers.run("{}:{}".format(self.config.repo, save_tag),
-                                          command="sh -c '/search --json {}'".format(json.dumps(json.dumps(search_args))), volumes=volumes, detach=True)
+                                          command="sh -c '/search --json {}'".format(json.dumps(json.dumps(search_args))),
+                                          volumes=volumes, detach=True, publish_all_ports=True)
 
         print("Logs for search in container with ID {}...".format(container.id))
         for line in container.logs(stream=True):


### PR DESCRIPTION
This ensures that all ports `EXPOSE`'d in the `Dockerfile` are accessible on the host.

For example, the line `EXPOSE 8983` would map the container's port `8983` to a random, available port on the host which can be accessed by the user.